### PR TITLE
fix: remove debug logs that leak client secret, access token, and signatures

### DIFF
--- a/_controllers/tokenController.js
+++ b/_controllers/tokenController.js
@@ -28,8 +28,6 @@ class TokenController{
         let timestamp = request.get('x-timestamp');
         const signature = TokenService.generateSignatureV2(privateKey, clientId, timestamp,request);
         let requestSignature = request.get('x-signature');
-        console.log(signature)
-        console.log(requestSignature)
         return TokenService.compareSignaturesV2(requestSignature,signature)
        
     }

--- a/_modules/snap.js
+++ b/_modules/snap.js
@@ -353,8 +353,6 @@ class Snap{
     
         let tokenController = new TokenController();
         let isTokenInvalid = tokenController.isTokenInvalid(this.tokenB2B, this.tokenExpiresIn, this.tokenGeneratedTimestamp);
-        console.log(this.tokenB2B)
-        console.log(isTokenInvalid)
         if(isTokenInvalid){
             await this.getTokenB2B();
         }

--- a/_services/tokenService.js
+++ b/_services/tokenService.js
@@ -217,7 +217,6 @@ module.exports = {
     createSignature(rawData, secretKey){
         let signatureUtf8 = CryptoJS.enc.Utf8.parse(rawData);
         var secretUtf8 = CryptoJS.enc.Utf8.parse(secretKey);
-        console.log("secretKey: " + secretKey);
         var signatureBytes = CryptoJS.HmacSHA512(signatureUtf8,secretUtf8);
         var requestSignatureBase64String = CryptoJS.enc.Base64.stringify(signatureBytes);
         return requestSignatureBase64String;


### PR DESCRIPTION
Removes leftover `console.log` debug statements that print sensitive authentication material to stdout:

- `_services/tokenService.js` — logs the `secretKey` argument in `createSignature`
- `_modules/snap.js` — logs the live B2B access token (`this.tokenB2B`)
- `_controllers/tokenController.js` — logs the request/computed signatures in `validateSignatureV2`

These end up in application logs, CI output, and crash reports, which is a credential-leak risk for a payment SDK. No behavior or logic changes. Found while integrating DOKU SNAP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
